### PR TITLE
Remove calls to `.all` with arguments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,16 +7,16 @@ GIT
       redis (>= 2.2.2)
 
 GIT
-  remote: git://github.com/ryanb/nested_form.git
-  revision: 1b0689dfb4d230ceabd278eba159fcb02f23c68a
-  specs:
-    nested_form (0.3.2)
-
-GIT
   remote: git://github.com/rubyzip/rubyzip.git
   revision: 070411ef5c60891356f5b539fc8969884f740487
   specs:
     rubyzip (1.1.7)
+
+GIT
+  remote: git://github.com/ryanb/nested_form.git
+  revision: 1b0689dfb4d230ceabd278eba159fcb02f23c68a
+  specs:
+    nested_form (0.3.2)
 
 GIT
   remote: git://github.com/tsujigiri/mendeley.git

--- a/app/controllers/picture_phenotypes_controller.rb
+++ b/app/controllers/picture_phenotypes_controller.rb
@@ -75,9 +75,9 @@ class PicturePhenotypesController < ApplicationController
           check_and_award_additional_phenotypes(20, "Entered 20 additional phenotypes")
           check_and_award_additional_phenotypes(50, "Entered 50 additional phenotypes")
           check_and_award_additional_phenotypes(100, "Entered 100 additional phenotypes")
-          
+
           #Sidekiq::Client.enqueue(Recommendvariations)
-      	  #Sidekiq::Client.enqueue(Recommendphenotypes)
+          #Sidekiq::Client.enqueue(Recommendphenotypes)
 
           redirect_to current_user
         else
@@ -96,14 +96,16 @@ class PicturePhenotypesController < ApplicationController
     #@phenotypes = Phenotype.where(:user_id => current_user.id).all
     #@title = "Phenotypes"
     @phenotype = PicturePhenotype.find(params[:id]) || not_found
-    @comments = PicturePhenotypeComment.where(:picture_phenotype_id => params[:id]).all(:order => "created_at ASC")
+    @comments = PicturePhenotypeComment
+      .where(:picture_phenotype_id => params[:id])
+      .order(:created_at)
     @phenotype_comment = PicturePhenotypeComment.new
     if current_user and UserPicturePhenotype.find_by_user_id_and_picture_phenotype_id(current_user.id,@phenotype.id)
       @user_phenotype = UserPicturePhenotype.find_by_user_id_and_picture_phenotype_id(current_user.id,@phenotype.id)
     else
       @user_phenotype = UserPicturePhenotype.new
     end
-    
+
     respond_to do |format|
       format.html
       format.xml
@@ -140,7 +142,7 @@ class PicturePhenotypesController < ApplicationController
   def sort_direction
     %w[desc asc].include?(params[:direction]) ? params[:direction] : "desc"
   end
-  
+
   def check_and_award_new_phenotypes(amount, achievement_string)
     @achievement = Achievement.find_by_award(achievement_string)
     if current_user.phenotype_creation_counter >= amount and UserAchievement.find_by_achievement_id_and_user_id(@achievement.id,current_user.id) == nil

--- a/lib/tasks/print_stats.rake
+++ b/lib/tasks/print_stats.rake
@@ -1,21 +1,21 @@
 namespace :all do
   desc "prints all created_at for all snps, genotypings, users, user_snps, phenotypes, user_phenotypes"
   task :print => :environment do
-        u_fh = open("users.txt","w")
-        User.all(:order => "created_at ASC").each do |u|
-                u_fh.write( "#{u.id}\t#{u.created_at}\n")
-        end
-        g_fh = open("genotypes.txt","w")
-        Genotype.all(:order => "created_at ASC").each do |u|
-                g_fh.write( "#{u.id}\t#{u.created_at}\n")
-        end
-        p_fh = open("phenotypes.txt","w")
-        Phenotype.all(:order => "created_at ASC").each do |u|
-                p_fh.write( "#{u.id}\t#{u.created_at}\n")
-        end
-        up_fh = open("user_phenotypes.txt","w")
-        UserPhenotype.all(:order => "created_at ASC").each do |u|
-                up_fh.write( "#{u.id}\t#{u.created_at}\n")
-        end
+    u_fh = open("users.txt","w")
+    User.order(:created_at).each do |u|
+      u_fh.write( "#{u.id}\t#{u.created_at}\n")
+    end
+    g_fh = open("genotypes.txt","w")
+    Genotype.order(:created_at).each do |u|
+      g_fh.write( "#{u.id}\t#{u.created_at}\n")
+    end
+    p_fh = open("phenotypes.txt","w")
+    Phenotype.order(:created_at).each do |u|
+      p_fh.write( "#{u.id}\t#{u.created_at}\n")
+    end
+    up_fh = open("user_phenotypes.txt","w")
+    UserPhenotype.order(:created_at).each do |u|
+      up_fh.write( "#{u.id}\t#{u.created_at}\n")
+    end
   end
 end


### PR DESCRIPTION
These are broken since the Rails 4 update.