### PR TITLE
Add default queue to Sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,6 +17,7 @@
  - [frequency,1]
  - [fixphenotypes,1]
  - [mailers, 1]
+ - [default, 1]
 # - [mendeley_details,1]
 # - [mendeley,1]
 # - [genomegov,1]


### PR DESCRIPTION
Contrary to what the Sidekiq documentation[1] says, mail is not put into the
`mailers` queue, but into the `default` queue. I found the default queue to be full with finished parsing mails and started a second Sidekiq instance on the command line to get them out.

[1] - https://github.com/mperham/sidekiq/wiki/Active-Job