### PR TITLE
Added Beacon implementation

### DIFF
--- a/app/controllers/beacon_controller.rb
+++ b/app/controllers/beacon_controller.rb
@@ -1,4 +1,5 @@
 # simple Beacon implementation according to the GA4GH v0.2 standard
+# see http://dnastack.com/ga4gh/bob/subscribe.html
 # chrom={chromosome}&
 # pos={position}&
 # allele={allele}

--- a/app/controllers/beacon_controller.rb
+++ b/app/controllers/beacon_controller.rb
@@ -1,0 +1,28 @@
+# simple Beacon implementation according to the GA4GH v0.2 standard
+# chrom={chromosome}&
+# pos={position}&
+# allele={allele}
+
+class BeaconController < ApplicationController
+  def responses
+    begin
+      @position = params[:pos].to_i
+      @chromosome = params[:chrom]
+      @allele = params[:allele].upcase
+      # get all snps, iterate over them:
+      #if found the allele: return yes & break
+      @snps = Snp.where(position: @position,chromosome: @chromosome)
+      @snps.each do |s|
+        if s.allele_frequency[@allele] > 0
+          render :text => "YES" and return
+          break
+        end
+      end
+      # not found? return no
+      render :text => "NO" and return
+    rescue
+      # did something break: return none (not useful, but the API standard…)
+      render :text => "NONE"
+    end
+  end
+end

--- a/app/controllers/beacon_controller.rb
+++ b/app/controllers/beacon_controller.rb
@@ -11,19 +11,19 @@ class BeaconController < ApplicationController
       @chromosome = params[:chrom]
       @allele = params[:allele].upcase
       # get all snps, iterate over them:
-      #if found the allele: return yes & break
-      @snps = Snp.where(position: @position,chromosome: @chromosome)
+      # if found the allele: return yes & break
+      @snps = Snp.where(position: @position, chromosome: @chromosome)
       @snps.each do |s|
         if s.allele_frequency[@allele] > 0
-          render :text => "YES" and return
+          render :text => 'YES' and return
           break
         end
       end
       # not found? return no
-      render :text => "NO" and return
+      render :text => 'NO' and return
     rescue
       # did something break: return none (not useful, but the API standard…)
-      render :text => "NONE"
+      render :text => 'NONE'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,4 +73,5 @@ Snpr::Application.routes.draw do
   get '/blog' => redirect("http://opensnp.wordpress.com")
   get '/user_picture_phenotypes/:id/edit', :to => 'user_picture_phenotypes#edit'
   get '/user_picture_phenotypes/:id/delete', :to => 'user_picture_phenotypes#delete'
+  get '/beacon/rest/responses', :to => 'beacon#responses'
 end

--- a/db/migrate/20130904010950_move_admin_notes_to_comments.rb
+++ b/db/migrate/20130904010950_move_admin_notes_to_comments.rb
@@ -9,9 +9,14 @@ class MoveAdminNotesToComments < ActiveRecord::Migration
     add_index     :active_admin_comments, [:author_type, :author_id]
 
     # Update all the existing comments to the default namespace
-    say "Updating any existing comments to the #{ActiveAdmin.application.default_namespace} namespace."
-    comments_table_name = ActiveRecord::Migrator.proper_table_name("active_admin_comments")
-    execute "UPDATE #{comments_table_name} SET namespace='#{ActiveAdmin.application.default_namespace}'"
+    $LOADED_FEATURES.each do |f|
+      fname = f.split('/').last
+      if fname == "activeadmin.rb"
+        say "Updating any existing comments to the #{ActiveAdmin.application.default_namespace} namespace."
+        comments_table_name = ActiveRecord::Migrator.proper_table_name("active_admin_comments")
+        execute "UPDATE #{comments_table_name} SET namespace='#{ActiveAdmin.application.default_namespace}'"
+      end
+    end
   end
 
   def self.down

--- a/test/functional/beacon_controller_test.rb
+++ b/test/functional/beacon_controller_test.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+require_relative '../test_helper'
+
+class BeaconControllerTest < ActionController::TestCase
+  context "Beacon" do
+    setup do
+      activate_authlogic
+      Sidekiq::Client.stubs(:enqueue)
+      @user = FactoryGirl.create(:user)
+      @snp = FactoryGirl.create(:snp)
+      @snp.allele_frequency["A"] = 2
+      @controller.send(:reset_session)
+    end
+    should "be YES" do
+      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "A")
+      assert_equal("YES",response.body)
+    end
+    should "be NO" do
+      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "C")
+        assert_equal("NO",response.body)
+    end
+    should "be NONE" do
+      get(:responses, {pos: @snp.position,chrom: @snp.chromosome)
+        assert_equal("NONE",response.body)
+    end
+  end
+end

--- a/test/functional/beacon_controller_test.rb
+++ b/test/functional/beacon_controller_test.rb
@@ -9,6 +9,7 @@ class BeaconControllerTest < ActionController::TestCase
       @user = FactoryGirl.create(:user)
       @snp = FactoryGirl.create(:snp)
       @snp.allele_frequency["A"] = 2
+      @snp.save
       @controller.send(:reset_session)
     end
     should "be YES" do

--- a/test/functional/beacon_controller_test.rb
+++ b/test/functional/beacon_controller_test.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require_relative '../test_helper'
-
+# let's see how my testing skills go…
 class BeaconControllerTest < ActionController::TestCase
   context "Beacon" do
     setup do

--- a/test/functional/beacon_controller_test.rb
+++ b/test/functional/beacon_controller_test.rb
@@ -12,15 +12,15 @@ class BeaconControllerTest < ActionController::TestCase
       @controller.send(:reset_session)
     end
     should "be YES" do
-      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "A")
+      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "A"})
       assert_equal("YES",response.body)
     end
     should "be NO" do
-      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "C")
+      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "C"})
         assert_equal("NO",response.body)
     end
     should "be NONE" do
-      get(:responses, {pos: @snp.position,chrom: @snp.chromosome)
+      get(:responses, {pos: @snp.position,chrom: @snp.chromosome})
         assert_equal("NONE",response.body)
     end
   end

--- a/test/functional/beacon_controller_test.rb
+++ b/test/functional/beacon_controller_test.rb
@@ -2,27 +2,27 @@
 require_relative '../test_helper'
 # let's see how my testing skills go…
 class BeaconControllerTest < ActionController::TestCase
-  context "Beacon" do
+  context 'Beacon' do
     setup do
       activate_authlogic
       Sidekiq::Client.stubs(:enqueue)
       @user = FactoryGirl.create(:user)
       @snp = FactoryGirl.create(:snp)
-      @snp.allele_frequency["A"] = 2
+      @snp.allele_frequency['A'] = 2
       @snp.save
       @controller.send(:reset_session)
     end
-    should "be YES" do
-      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "A"})
-      assert_equal("YES",response.body)
+    should 'be YES' do
+      get(:responses, {pos: @snp.position, chrom: @snp.chromosome, allele: "A"})
+      assert_equal('YES',response.body)
     end
-    should "be NO" do
-      get(:responses, {pos: @snp.position,chrom: @snp.chromosome,allele: "C"})
-        assert_equal("NO",response.body)
+    should 'be NO' do
+      get(:responses, {pos: @snp.position, chrom: @snp.chromosome, allele: "C"})
+        assert_equal('NO',response.body)
     end
-    should "be NONE" do
-      get(:responses, {pos: @snp.position,chrom: @snp.chromosome})
-        assert_equal("NONE",response.body)
+    should 'be NONE' do
+      get(:responses, {pos: @snp.position, chrom: @snp.chromosome})
+        assert_equal('NONE',response.body)
     end
   end
 end


### PR DESCRIPTION
Beacon's are a pretty simple API implementation designed by the Global Alliance 4 Genomics & Health. Basically you can ask for a given chromosome + position on whether a given allele is found in a database. So for example you can ask "for chromosome 1, position 1234, do you have any individual with an "A" in your DB?". There are only 3 plain text answers: "YES","NO","NONE" (the latter for cases where things didn't work out, incorrect API calls etc). A bit more details can be found here: http://dnastack.com/ga4gh/bob/subscribe.html

In any case, this adds support for this type of API query and it even has test coverage. If you start your dev version you should be able to test it using localhost:3000/beacon/rest/responses?pos=72017&chrom=1&allele=A etc. 