### PR TITLE
Add default scopes, excluding HSTORE columns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,3 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 20
-
-Style/MultilineOperationIndentation:
-  EnforcedStyle: indented
-

--- a/app/controllers/user_snps_controller.rb
+++ b/app/controllers/user_snps_controller.rb
@@ -1,7 +1,7 @@
 class UserSnpsController < ApplicationController
-	def show
-		@user_snps = UserSnp.where(:user_id => current_user.id).paginate(:page => params[:page])
-	end
+  def show
+    @user_snps = UserSnp.where(user_id: current_user.id).paginate(page: params[:page])
+  end
 
   def index
     @local_genotype = params[:local_genotype].presence
@@ -9,7 +9,7 @@ class UserSnpsController < ApplicationController
       @user_snps = Snp.find_by_name(params[:snp_name]).user_snps.includes(:user)
       render layout: false
     else
-      render text: "Something went wrong.", layout: false
+      render text: 'Something went wrong.', layout: false
     end
   end
 end

--- a/app/models/concerns/ignore_columns.rb
+++ b/app/models/concerns/ignore_columns.rb
@@ -1,0 +1,12 @@
+module IgnoreColumns
+  def ignore_columns(*ignored_columns)
+    default_scope { select(column_names - ignored_columns.map(&:to_s)) }
+  end
+
+  def count
+    # The default scope breaks the regular `count` method, due to
+    # `COUNT(co1, col2, ...)` being invalid SQL syntax. This workaround seems to
+    # work for most cases.
+    pluck('count(*)').first
+  end
+end

--- a/app/models/genotype.rb
+++ b/app/models/genotype.rb
@@ -19,6 +19,9 @@ class Genotype < ActiveRecord::Base
   default_scope { select(column_names - ['snps']) }
 
   def self.count
+    # The default scope breaks the regular `count` method, due to
+    # `COUNT(co1, col2, ...)` being invalid SQL syntax. This workaround seems to
+    # work for most cases.
     pluck('count(*)').first
   end
 

--- a/app/models/genotype.rb
+++ b/app/models/genotype.rb
@@ -1,6 +1,8 @@
 require 'fileutils'
 
 class Genotype < ActiveRecord::Base
+  extend IgnoreColumns
+
   belongs_to :user
   has_many :user_snps
   validates_presence_of :user
@@ -16,14 +18,7 @@ class Genotype < ActiveRecord::Base
   after_create :parse_genotype
   before_destroy :delete_genotype
 
-  default_scope { select(column_names - ['snps']) }
-
-  def self.count
-    # The default scope breaks the regular `count` method, due to
-    # `COUNT(co1, col2, ...)` being invalid SQL syntax. This workaround seems to
-    # work for most cases.
-    pluck('count(*)').first
-  end
+  ignore_columns :snps
 
   def is_image?
     false

--- a/app/models/genotype.rb
+++ b/app/models/genotype.rb
@@ -16,6 +16,12 @@ class Genotype < ActiveRecord::Base
   after_create :parse_genotype
   before_destroy :delete_genotype
 
+  default_scope { select(column_names - ['snps']) }
+
+  def self.count
+    pluck('count(*)').first
+  end
+
   def is_image?
     false
   end

--- a/app/models/snp.rb
+++ b/app/models/snp.rb
@@ -1,5 +1,6 @@
 class Snp < ActiveRecord::Base
   include PgSearchCommon
+  extend IgnoreColumns
 
   has_many :user_snps, foreign_key: :snp_name, primary_key: :name
   has_many :users, through: :user_snps
@@ -19,14 +20,7 @@ class Snp < ActiveRecord::Base
 
   after_create :default_frequencies
 
-  default_scope { select(column_names - ['genotypes']) }
-
-  def self.count
-    # The default scope breaks the regular `count` method, due to
-    # `COUNT(co1, col2, ...)` being invalid SQL syntax. This workaround seems to
-    # work for most cases.
-    pluck('count(*)').first
-  end
+  ignore_columns :genotypes
 
   def default_frequencies
     # if variations is empty, put in our default array

--- a/app/models/snp.rb
+++ b/app/models/snp.rb
@@ -19,6 +19,12 @@ class Snp < ActiveRecord::Base
 
   after_create :default_frequencies
 
+  default_scope { select(column_names - ['genotypes']) }
+
+  def self.count
+    pluck('count(*)').first
+  end
+
   def default_frequencies
     # if variations is empty, put in our default array
     self.allele_frequency ||= { "A" => 0, "T" => 0, "G" => 0, "C" => 0}

--- a/app/models/snp.rb
+++ b/app/models/snp.rb
@@ -22,6 +22,9 @@ class Snp < ActiveRecord::Base
   default_scope { select(column_names - ['genotypes']) }
 
   def self.count
+    # The default scope breaks the regular `count` method, due to
+    # `COUNT(co1, col2, ...)` being invalid SQL syntax. This workaround seems to
+    # work for most cases.
     pluck('count(*)').first
   end
 

--- a/app/workers/preparsing.rb
+++ b/app/workers/preparsing.rb
@@ -82,7 +82,7 @@ class Preparsing
     logger.info "Checking whether genotyping is duplicate"
     md5 = Digest::MD5.file("#{Rails.root}/public/data/#{genotype.fs_filename}").to_s
     file_is_duplicate = false
-    if Genotype.where(md5sum: md5).where('id != ?', genotype.id).count > 0
+    if Genotype.unscoped.where(md5sum: md5).where('id != ?', genotype.id).count > 0
       file_is_duplicate = true
       logger.info "Genotyping #{genotype.genotype.path} is already uploaded!\n"
       logger.info "Genotyping #{genotype.fs_filename} has the same md5sum.\n"

--- a/app/workers/preparsing.rb
+++ b/app/workers/preparsing.rb
@@ -82,7 +82,7 @@ class Preparsing
     logger.info "Checking whether genotyping is duplicate"
     md5 = Digest::MD5.file("#{Rails.root}/public/data/#{genotype.fs_filename}").to_s
     file_is_duplicate = false
-    if Genotype.unscoped.where(md5sum: md5).where('id != ?', genotype.id).count > 0
+    if Genotype.unscoped.where(md5sum: md5).where.not(id: genotype.id).count > 0
       file_is_duplicate = true
       logger.info "Genotyping #{genotype.genotype.path} is already uploaded!\n"
       logger.info "Genotyping #{genotype.fs_filename} has the same md5sum.\n"


### PR DESCRIPTION
In preparation for #189, exclude the coming HSTORE columns, so we can migrate in the background, without disrupting service.