### PR TITLE
Make tests fail if test coverage drops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ api_key.txt
 config/app_config.yml
 config/database.yml
 config/newrelic.yml
-coverage
+coverage/*
+!coverage/.last_run.json
 db/*.sqlite3
 development.log
 dump.rdb

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,3 @@
+SimpleCov.start('rails') do
+  refuse_coverage_drop
+end

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby # Defaults to ruby, but travis-ci recommends making this explicit.
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
 env: DB=postgres CI=1
 bundler_args: --without development debug

--- a/bin/rails
+++ b/bin/rails
@@ -5,6 +5,8 @@ rescue LoadError
 end
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
+require 'simplecov' if ENV['RAILS_ENV'] == 'test'
+
 APP_PATH = File.expand_path('../../config/application',  __FILE__)
 require File.expand_path('../../config/boot',  __FILE__)
 require 'rails/commands'

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,0 +1,5 @@
+{
+  "result": {
+    "covered_percent": 51.52
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
+
+require 'simplecov'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'sidekiq/testing'


### PR DESCRIPTION
If I did this correctly, the tests should always fail, if the test-coverage drops. If it increases, `coverage/.last_run.json` should be updated automatically. Don't forget to commit changes to it.