### PR TITLE
Makes sure that papers' SNPs are unique. Adds non-working rake task to make papers' SNPs unique.

### DIFF
--- a/app/workers/mendeley_search.rb
+++ b/app/workers/mendeley_search.rb
@@ -74,7 +74,7 @@ class MendeleySearch
           logger.error("MendeleyPaper for #{snp.name} invalid.\n" <<
                        mendeley_paper.errors.full_messages.join(", "))
         else
-          mendeley_paper.snps << snp
+          mendeley_paper.snps << snp unless mendeley_paper.snps.include? snp
         end
         Sidekiq::Client.enqueue(MendeleyDetails, mendeley_paper.id)
       end

--- a/app/workers/plos_search.rb
+++ b/app/workers/plos_search.rb
@@ -33,7 +33,7 @@ class PlosSearch
     }
     plos_paper = PlosPaper.find_or_initialize_by(doi: plos_paper_attributes[:doi])
     plos_paper.update_attributes!(plos_paper_attributes)
-    plos_paper.snps << snp
+    plos_paper.snps << snp unless plos_paper.snps.include? snp
     Sidekiq::Client.enqueue(PlosDetails, plos_paper.id)
   end
 

--- a/app/workers/snpedia.rb
+++ b/app/workers/snpedia.rb
@@ -31,7 +31,7 @@ class Snpedia
       /summary=(?<summary>.*)\}\}/m =~ to_parse
       snpedia_paper.update_attributes!(
         url: url, summary: summary, revision: rev_id)
-      snpedia_paper.snps << snp
+      snpedia_paper.snps << snp unless snpedia_paper.snps.include? snp
       snpedia_updated = true
     end
     snp.snpedia_updated! if snpedia_updated

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 55.81
+    "covered_percent": 51.41
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 51.41
+    "covered_percent": 55.81
   }
 }

--- a/lib/tasks/make_paper_snps_unique.rake
+++ b/lib/tasks/make_paper_snps_unique.rake
@@ -1,0 +1,9 @@
+namespace :papers do
+  task :make_linked_snps_unique => :environment do
+    %w(MendeleyPaper SnpediaPaper PlosPaper).each do |source|
+      source.constantize.find_each do |s|
+        s.update(snps: s.snps.uniq)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should hopefully prevent #202 from happening again 

The Rake task doesn't work right now for some strange reason. It calls commit and everything but the paper remains "broken". I should drink more coffee.

(We can circumvent this issue by just storing all snps in a set instead of an array, but it's not really an array but a ActiveRecord::Associations::CollectionProxy)