### PR TITLE
Revert "Make tests fail if test coverage drops"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ api_key.txt
 config/app_config.yml
 config/database.yml
 config/newrelic.yml
-coverage/*
-!coverage/.last_run.json
+coverage
 db/*.sqlite3
 development.log
 dump.rdb

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,0 @@
-SimpleCov.start('rails') do
-  refuse_coverage_drop
-end

--- a/bin/rails
+++ b/bin/rails
@@ -5,8 +5,6 @@ rescue LoadError
 end
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-require 'simplecov' if ENV['RAILS_ENV'] == 'test'
-
 APP_PATH = File.expand_path('../../config/application',  __FILE__)
 require File.expand_path('../../config/boot',  __FILE__)
 require 'rails/commands'

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,0 @@
-{
-  "result": {
-    "covered_percent": 51.41
-  }
-}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
-
-require 'simplecov'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'sidekiq/testing'


### PR DESCRIPTION
This reverts commit 3142abe96dffec6cfc4a86fab4602c9a45458ef3.

Since the coverage metric doesn't seem to be consistent across different machines/Ruby versions/builds, let's revert this for now.