### PR TITLE
Trigger Docker Hub build of dev image

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -3,3 +3,7 @@
 curl -X POST \
      -d "build=true&source_type=Branch&source_name=master" \
      https://registry.hub.docker.com/u/opensnp/rails/trigger/$DOCKERHUB_TRIGGER_TOKEN/ 
+
+curl -X POST \
+     -d "build=true&source_type=Branch&source_name=master" \
+     https://registry.hub.docker.com/u/opensnp/rails/trigger/$DOCKERHUB_TRIGGER_TOKEN_DEV/


### PR DESCRIPTION
This will trigger a build of the dev image on Docker Hub. This way we don't need to build it locally and only need to run `docker run opensnp/rails-dev` locally. To run it with the version in your current working directory, run docker with `docker run -v .:/home/app/snpr`.