### PR TITLE
Fix Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'recommendify', github: 'paulasmuth/recommendify', ref: '34308c4'
 gem 'sidekiq'
 gem 'sidekiq-limit_fetch'
 gem 'slim', '~> 1.3.8'
-gem 'sinatra'
+gem 'sinatra', require: false
 
 # cron jobs
 gem 'whenever', require: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require 'sidekiq/web'
+
 Snpr::Application.routes.draw do
   root :to => 'index#index' # change this, maybe
 
@@ -74,4 +76,6 @@ Snpr::Application.routes.draw do
   get '/user_picture_phenotypes/:id/edit', :to => 'user_picture_phenotypes#edit'
   get '/user_picture_phenotypes/:id/delete', :to => 'user_picture_phenotypes#delete'
   get '/beacon/rest/responses', :to => 'beacon#responses'
+
+  mount Sidekiq::Web => '/sidekiq'
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,18 +14,18 @@
   - [frequency,1]
   - [fixphenotypes,1]
   - [default, 1]
-# - [mailnewgenotype, 10]
-# - [mailers, 1]
-#  - [user_snps, 3]
-#- [preparse,3]
-#  - [parse,3]
-#  - [mendeley_details,1]
-#  - [mendeley,1]
-#  - [genomegov,1]
-#  - [pgp,1]
-#  - [plos_details,1]
-#  - [plos,1]
-#  - [snpedia,1]
+  - [mailnewgenotype, 10]
+  - [mailers, 1]
+  - [user_snps, 3]
+  - [preparse,3]
+  - [parse,3]
+  - [mendeley_details,1]
+  - [mendeley,1]
+  - [genomegov,1]
+  - [pgp,1]
+  - [plos_details,1]
+  - [plos,1]
+  - [snpedia,1]
 :limits:
   recommend: 1
   zipgenotyping: 1
@@ -33,14 +33,14 @@
   fitbit: 3
   frequency: 10
   fixphenotypes: 1
-#  mailnewgenotype: 1
-# user_snps: 1
-#  preparse: 2
-#  parse: 1
-#  genomegov: 1
-#  mendeley_details: 1
-#  mendeley: 1
-#  pgp: 1
-#  plos_details: 1
-#  plos: 1
-#  snpedia: 1
+  mailnewgenotype: 1
+  user_snps: 1
+  preparse: 2
+  parse: 1
+  genomegov: 1
+  mendeley_details: 1
+  mendeley: 1
+  pgp: 1
+  plos_details: 1
+  plos: 1
+  snpedia: 1

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,6 @@
 ---
 :verbose: true
 :pidfile: tmp/pids/sidekiq.pid
-:logfile: ./log/sidekiq.log
 :global: true
 :concurrency: 10
 


### PR DESCRIPTION
In which I prepare Sidekiq for imminent reinstatement.

After deploying this and before actually running Sidekiq again, the `mailers` (and `mailnewgenotypes`?) queues should be emptied in order to prevent the emails, enqueued when testing the alternative parser, from being sent.